### PR TITLE
CI: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -1,0 +1,38 @@
+---
+name: 🐜 Bug report
+about: Create a bug report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Describe the bug
+
+<!--- A clear and concise description of what the bug is. -->
+
+<!--- HINT: You can paste gist.github.com links for long logs or larger files -->
+
+### Steps to reproduce
+
+1.
+2.
+3.
+
+### Expected behavior
+
+<!--- A clear and concise description of what you expected to happen. -->
+
+### Screenshots
+
+<!--- If applicable, add screenshots to help explain your problem. -->
+
+### Cobbler version
+
+<!--- Paste output from `cobbler version` -->
+````paste below
+````
+
+### Additional information
+
+<!--- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/02_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.md
@@ -1,0 +1,28 @@
+---
+name:  🚀 Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+### Is your feature request related to a problem?
+
+<!-- Please mind the double space at the end to keep the markdown linebreak intact! -->
+
+As a <!-- please describe your role -->  
+I want to <!-- please describe the goal -->  
+so that I can <!-- please describe the purpose why you want to reach your goal -->
+
+### Provide a detailed description of the proposed feature
+
+<!--- A clear and concise description of what you want to happen. -->
+
+### Alternatives you've considered
+
+<!--- A clear and concise description of any alternative solutions or features you've considered. -->
+
+### Additional information
+
+<!--- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ❓ Questions
+    url: https://github.com/cobbler/cobblerclient/discussions
+    about: Ask questions here
+  - name: 💬 Matrix Chat
+    url: https://app.element.io/#/room/#cobbler_community:gitter.im
+    about: Chat with the Cobbler community
+  - name: 📬 Development mailing list
+    url: https://groups.google.com/forum/#!forum/cobbler-users
+    about: The developer mailing list


### PR DESCRIPTION
Fixes #29 

This PR adds issue templates that were taken from the new Golang-based CLI.