### PR TITLE
Client: Parse and return ExtendedVersion Struct

### DIFF
--- a/cobblerclient_test.go
+++ b/cobblerclient_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cobblerclient
 
 import (
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -193,9 +194,19 @@ func TestVersion(t *testing.T) {
 
 func TestExtendedVersion(t *testing.T) {
 	c := createStubHTTPClient(t, "extended-version-req.xml", "extended-version-res.xml")
+	expectedResult := ExtendedVersion{
+		Gitdate:      "Mon Jun 13 16:13:33 2022 +0200",
+		Gitstamp:     "0e20f01b",
+		Builddate:    "Mon Jun 27 06:34:23 2022",
+		Version:      "3.4.0",
+		VersionTuple: []int{3, 4, 0},
+	}
 
-	err := c.ExtendedVersion()
+	result, err := c.ExtendedVersion()
 	utils.FailOnError(t, err)
+	if !reflect.DeepEqual(result, expectedResult) {
+		t.Errorf("Result from 'extended_version' did not match expected result.")
+	}
 }
 
 func TestGetReposCompatibleWithProfile(t *testing.T) {

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,8 @@
 package cobblerclient
 
-import "errors"
+import (
+	"errors"
+)
 
 func returnString(res interface{}, err error) (string, error) {
 	if err != nil {
@@ -19,6 +21,24 @@ func returnStringSlice(res interface{}, err error) ([]string, error) {
 
 	for _, name := range res.([]interface{}) {
 		result = append(result, name.(string))
+	}
+
+	return result, nil
+}
+
+func returnIntSlice(res interface{}, err error) ([]int, error) {
+	var result []int
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range res.([]interface{}) {
+		var parsedInt, err = convertToInt(name)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, parsedInt)
 	}
 
 	return result, nil


### PR DESCRIPTION
Fixes #33 

This exposes the `extended_version` endpoint that will enable the CLI to show the information to the user.