### PR TITLE
Client: Expose result of get_blended_data

### DIFF
--- a/cobblerclient.go
+++ b/cobblerclient.go
@@ -177,9 +177,9 @@ func (c *Client) GenerateScript(profile, system, name string) error {
 }
 
 // GetBlendedData passes a profile or system through Cobblers inheritance chain and returns the result.
-func (c *Client) GetBlendedData(profile, system string) error {
-	_, err := c.Call("get_blended_data", profile, system)
-	return err
+func (c *Client) GetBlendedData(profile, system string) (map[string]interface{}, error) {
+	result, err := c.Call("get_blended_data", profile, system)
+	return result.(map[string]interface{}), err
 }
 
 // GetSettings returns the currently active settings.

--- a/cobblerclient_test.go
+++ b/cobblerclient_test.go
@@ -144,8 +144,11 @@ func TestGenerateScript(t *testing.T) {
 func TestGetBlendedData(t *testing.T) {
 	c := createStubHTTPClient(t, "get-blended-data-req.xml", "get-blended-data-res.xml")
 
-	err := c.GetBlendedData("testprof", "")
+	result, err := c.GetBlendedData("testprof", "")
 	utils.FailOnError(t, err)
+	if len(result) != 184 {
+		t.Fatalf("Expected a map with 184 entries, got %d.", len(result))
+	}
 }
 
 func TestGetSettings(t *testing.T) {


### PR DESCRIPTION
Fixes #40 

Sadly it was not possible to return a well-defined struct since the method server-side used to realize this is `utils.blender()`. As such we can only narrow it down to `map[string]interface{}`.