### PR TITLE
Profile: Add three missing fields

### DIFF
--- a/profile.go
+++ b/profile.go
@@ -31,10 +31,13 @@ type Profile struct {
 	ReposEnabled bool `mapstructure:"repos_enabled"          cobbler:"noupdate"`
 
 	Autoinstall         string      `mapstructure:"autoinstall"`
+	BootLoaders         interface{} `mapstructure:"boot_loaders"`
 	DHCPTag             string      `mapstructure:"dhcp_tag"`
 	Distro              string      `mapstructure:"distro"`
 	EnableGPXE          bool        `mapstructure:"enable_gpxe"`
 	EnableMenu          interface{} `mapstructure:"enable_menu"`
+	Filename            string      `mapstructure:"filename"`
+	Menu                string      `mapstructure:"menu"`
 	NameServers         []string    `mapstructure:"name_servers"`
 	NameServersSearch   []string    `mapstructure:"name_servers_search"`
 	NextServerv4        string      `mapstructure:"next_server_v4"`


### PR DESCRIPTION
Fixes #53 

The three fields were overlooked to be added when completing the functionality of the client. Since "boot_loaders" can be both list and str (due to backend side inheritance) it must be of type interface.